### PR TITLE
Fixed error with adjure calls not being saved individually

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Adjure is a simple system to test url API's. Adjure simply allows you to send a 
 
 ###2.2.0
  - categorize requests
- - parse JSON body into url variables on GET requests
+ - ~~parse JSON body into url variables on GET requests~~

--- a/assets/js/adjure.js
+++ b/assets/js/adjure.js
@@ -156,7 +156,7 @@ Adjure.saveOne = function(index){
     if(Adjure.currentData.calls[index].isDirty) {
         Adjure.currentData.calls[index].isDirty = false;
         Adjure.storedData.calls[index] = Adjure.currentData.calls[index];
-        Adjure._save
+        Adjure._save();
         Adjure.setIsDirtyMarker(index, false)
     }
 };


### PR DESCRIPTION
I fixed the one line that was causing individual Adjure calls not to be saved.

I also updated the README to strikethrough the "parse JSON body into URL variables" task
